### PR TITLE
Boot order change and typo fix

### DIFF
--- a/etc/init.d/set_cpu_state
+++ b/etc/init.d/set_cpu_state
@@ -2,15 +2,15 @@
 #
 # set_cpu_state
 #
-# chkconfig: 345 99 99
+# chkconfig: 345 03 97
 # description:	Set CPU Frequency States
 #
 ### BEGIN INIT INFO
 # Provides: set_cpu_state
 # Required-Start: 
 # Required-Stop:
-# Default-Start: 99
-# Default-Stop: 99
+# Default-Start: 03
+# Default-Stop: 97
 # Short-Description: start and stop set_cpu_state
 # Description: Start and stop set_cpu_state
 ### END INIT INFO

--- a/usr/lib/functions.sh
+++ b/usr/lib/functions.sh
@@ -125,8 +125,8 @@ get_CPU_TOTAL_REAL_CORES() {
 }
 
 get_CPU_OFFLINE() {
-	my_CPU_OFFLINE_COUNT=$(grep -w 1 /sys/devices/system/cpu/cpu*/online | wc -l)
-	my_CPU_OFFLINE_LIST=$(grep -w 1 /sys/devices/system/cpu/cpu*/online | wc -l)
+	my_CPU_OFFLINE_COUNT=$(grep -w 0 /sys/devices/system/cpu/cpu*/online | wc -l)
+	my_CPU_OFFLINE_LIST=$(grep -w 0 /sys/devices/system/cpu/cpu*/online)
 }
 
 get_HYPERTHREADING_STATE() {


### PR DESCRIPTION
We ran into issues with set_cpu_state starting so late in the boot process, and moving it up fixes the problems.  Let me know if you need the gory details.  :-)
